### PR TITLE
Switch to an HTTPS url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "challenge-bypass-ristretto-ffi"]
 	path = challenge-bypass-ristretto-ffi
-	url = git@github.com:brave-intl/challenge-bypass-ristretto-ffi.git
+	url = https://github.com/brave-intl/challenge-bypass-ristretto-ffi


### PR DESCRIPTION
This allows the whole repo, submodules and all, to be cloned without an SSH key.
Since everything is public, requiring an SSH key adds little over using HTTPS.