### PR TITLE
Remove the unnecessary Darwin comparison and the junk hash.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # time of this comment.  We can bump it to a newer version when that
       # makes sense.  Meanwhile, the platform won't shift around beneath us
       # unexpectedly.
-      NIXPKGS_REV: "3c83ad6ac13b67101cc3e2e07781963a010c1624"
+      NIXPKGS_REV: "5d5cd70516001e79516d2ade8bcf31df208a4ef3"
 
     steps:
       - run:
@@ -24,7 +24,7 @@ jobs:
           # the `BASE_ENV` feature as we do here.
           name: "Setup NIX_PATH Environment Variable"
           command: |
-            echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$NIXPKGS_REV.tar.gz" >> $BASH_ENV
+            echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/$NIXPKGS_REV.tar.gz" >> $BASH_ENV
 
       # Get *our* source code.
       - "checkout"

--- a/privacypass.nix
+++ b/privacypass.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonPackage rec {
       --replace "['cargo', 'build', '--release']" "['sh', '-c', ':']" \
       --replace "./challenge-bypass-ristretto-ffi" "/" \
       --replace "target/release" "${ristretto}/lib" \
-      --replace "./src" "${src}/challenge-bypass-ristretto-ffi/src"
+      --replace "./src" "${ristretto.src}/src"
   '';
 
   nativeBuildInputs = [

--- a/ristretto.nix
+++ b/ristretto.nix
@@ -16,17 +16,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1gf7ki3q6d15bq71z8s3pc5l2rsp1zk5bqviqlwq7czg674g7zw2";
   };
 
-  # XXX It's not clear why the hash is different on Darwin.  #nixos suggested
-  # something like "Unicode normalization [on files] sometimes differs".  I
-  # didn't find anything in the issue tracker and the paths all look pretty
-  # boring and normal to me but maybe this includes all paths from transitive
-  # dependencies, too.  Anyway, the difference is *stable* so it doesn't
-  # really matter.  It will mean updating two hashes when we bump our
-  # ristretto version but that's not too bad.
-  cargoSha256 =
-    if stdenv.isDarwin
-      then "1vfzdvpjj6s94p650zvai8gz89hj5ldrakci5l15n33map1iggch"
-      else "1qbfp24d21wg13sgzccwn3ndvrzbydg0janxp7mzkjm4a83v0qij";
+  cargoSha256 = "1vfzdvpjj6s94p650zvai8gz89hj5ldrakci5l15n33map1iggch";
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 


### PR DESCRIPTION
The behavior never really differed between NixOS and Darwin.  Instead, it
differed between my Nix store and everyone else's.  Mine got populated with
incorrect data at some point in the past.  Since cargoSha256 feeds into a
"fixed output derivation", Nix just believed me when I told it the cargoSha256
because it already had a store object matching that hash.

Everyone else has to fetch crates from the internet and Nix has to compute
their hashes.  When it does, it finds they don't match because they're
actually different from whatever data I had on my system.

The fix is to purge the poisoned Nix store paths on my system, not maintain
two separate hashes.